### PR TITLE
【Compile was successful】Replace with "openzeppelin-solidity" (v2.4.0) and "@openzeppelin/upgrades" (v2.7.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "author": "masaun",
   "license": "MIT",
   "dependencies": {
-    "@openzeppelin/contracts": "^2.5.1",
+    "@openzeppelin/upgrades": "^2.7.2",
+    "openzeppelin-solidity": "2.4.0",
     "@truffle/hdwallet-provider": "^1.2.0",
     "dotenv": "^8.2.0",
     "eth-block-tracker": "^4.4.3",


### PR DESCRIPTION
### Replace OpenZeppelin module with：
- openzeppelin-solidity(v2.4.0) 
- @openzeppelin/upgrades(v2.7.2)

<br>

- Ref：https://github.com/keep-network/keep-core/blob/master/solidity/package.json#L32-L33